### PR TITLE
Reserve table tags for StripEmpty node visitor

### DIFF
--- a/mammoth/html/__init__.py
+++ b/mammoth/html/__init__.py
@@ -17,7 +17,7 @@ def tag(tag_names, attributes=None, collapsible=None, separator=None):
 def element(tag_names, attributes=None, children=None, collapsible=None, separator=None):
     if children is None:
         children = []
-        
+
     element_tag = tag(tag_names=tag_names, attributes=attributes, collapsible=collapsible, separator=separator)
     return Element(element_tag, children)
 
@@ -38,41 +38,45 @@ def _strip_empty_node(node):
 
 
 class StripEmpty(NodeVisitor):
+    _RESERVED_TAG_NAMES = set(['tr', 'th', 'td'])
+
     def visit_text_node(self, node):
         if node.value:
             return [node]
         else:
             return []
-    
+
     def visit_element(self, element):
         children = strip_empty(element.children)
-        if len(children) == 0 and not element.is_void():
+        if len(children) == 0 and not element.is_void() and element.tag_name not in self._RESERVED_TAG_NAMES:
             return []
         else:
             return [Element(element.tag, children)]
-    
+
     def visit_force_write(self, node):
         return [node]
 
 
 def collapse(nodes):
     collapsed = []
-    
+
     for node in nodes:
         _collapsing_add(collapsed, node)
-    
+
     return collapsed
+
 
 class _CollapseNode(NodeVisitor):
     def visit_text_node(self, node):
         return node
-    
+
     def visit_element(self, element):
         return Element(element.tag, collapse(element.children))
-    
+
     def visit_force_write(self, node):
         return node
-    
+
+
 _collapse_node = _CollapseNode().visit
 
 
@@ -80,7 +84,8 @@ def _collapsing_add(collapsed, node):
     collapsed_node = _collapse_node(node)
     if not _try_collapse(collapsed, collapsed_node):
         collapsed.append(collapsed_node)
-    
+
+
 def _try_collapse(collapsed, node):
     if not collapsed:
         return False
@@ -88,20 +93,21 @@ def _try_collapse(collapsed, node):
     last = collapsed[-1]
     if not isinstance(last, Element) or not isinstance(node, Element):
         return False
-    
+
     if not node.collapsible:
         return False
-        
+
     if not _is_match(last, node):
         return False
-    
+
     if node.separator:
         last.children.append(text(node.separator))
-    
+
     for child in node.children:
         _collapsing_add(last.children, child)
-        
+
     return True
+
 
 def _is_match(first, second):
     return first.tag_name in second.tag_names and first.attributes == second.attributes
@@ -110,15 +116,15 @@ def _is_match(first, second):
 def write(writer, nodes):
     visitor = _NodeWriter(writer)
     visitor.visit_all(nodes)
-        
+
 
 class _NodeWriter(NodeVisitor):
     def __init__(self, writer):
         self._writer = writer
-    
+
     def visit_text_node(self, node):
         self._writer.text(node.value)
-    
+
     def visit_element(self, element):
         if element.is_void():
             self._writer.self_closing(element.tag_name, element.attributes)
@@ -126,10 +132,10 @@ class _NodeWriter(NodeVisitor):
             self._writer.start(element.tag_name, element.attributes)
             self.visit_all(element.children)
             self._writer.end(element.tag_name)
-    
+
     def visit_force_write(self, element):
         pass
-    
+
     def visit_all(self, nodes):
         for node in nodes:
             self.visit(node)

--- a/mammoth/writers/html.py
+++ b/mammoth/writers/html.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
+from xml.sax.saxutils import escape
 
 from .abc import Writer
-
-import cgi
 
 
 class HtmlWriter(Writer):
@@ -31,7 +30,7 @@ class HtmlWriter(Writer):
 
 
 def _escape_html(text):
-    return cgi.escape(text, quote=True)
+    return escape(text, {'"': "&quot;"})
 
 
 def _generate_attribute_string(attributes):

--- a/tests/html/strip_empty_tests.py
+++ b/tests/html/strip_empty_tests.py
@@ -45,7 +45,7 @@ def empty_children_are_removed():
             html.element("li", {}, [html.text("")]),
             html.element("li", {}, [html.text("H")]),
         ])]),
-        
+
         [html.element("ul", {}, [
             html.element("li", {}, [html.text("H")])
         ])])
@@ -63,3 +63,17 @@ def force_writes_are_never_empty():
     assert_equal(
         [html.force_write],
         html.strip_empty([html.force_write]))
+
+
+@istest
+def table_nodes_are_reserved():
+    elements = [html.element('table', {}, [
+        html.element('tr', {'rowspan': 2}, [
+            html.element('td', {}, [html.text('H')]),
+        ]),
+        html.element('tr', []),
+    ])]
+    assert_equal(
+        elements,
+        html.strip_empty(elements)
+    )


### PR DESCRIPTION
To avoid that `html.strip_empty` breaks table rowspan.